### PR TITLE
Update map extras

### DIFF
--- a/data/json/item_groups.json
+++ b/data/json/item_groups.json
@@ -7282,6 +7282,8 @@
   },{
     "type" : "item_group",
     "id" : "drugdealer",
+    "magazine": 100,
+    "ammo": 50,
     "items":[
       ["energy_drink", 55],
       ["energy_drink_atomic", 8],

--- a/data/json/map_extra_items.json
+++ b/data/json/map_extra_items.json
@@ -21,13 +21,7 @@
         "entries":
         [
             { "item": "corpse", "damage": 3 },
-            { "group": "mil_armor_torso", "damage-min": 1, "damage-max": 4, "prob": 40 },
-            { "group": "mil_armor_helmet", "damage-min": 1, "damage-max": 4, "prob": 30 },
-            { "group": "military", "damage-min": 1, "damage-max": 4, "prob": 86 },
-            { "item": "winter_pants_army", "damage-min": 1, "damage-max": 4 },
-            { "item": "boots_combat", "damage-min": 1, "damage-max": 4 },
-            { "item": "id_military", "prob": 12 },
-            { "group": "underwear", "damage-min": 1, "damage-max": 3 }
+            { "group": "mon_zombie_soldier_death_drops" }
         ]
     }, {
         "type" : "item_group",


### PR DESCRIPTION
Partially mitagates #18122 by simplifying mx_military in the same way that mx_roadblock was changed, and gives magazines to item_group "drugdealer". mx_helicopter requires lots of work that I lack the confidence to approach, and "rare" item added to map extras in C++ mapgen won't be fixed here.